### PR TITLE
Declare optional props as optional in TS

### DIFF
--- a/dist/column-resizer.d.ts
+++ b/dist/column-resizer.d.ts
@@ -1,21 +1,18 @@
 import { JSX } from "react";
 
 declare module "react-table-column-resizer" {
+  export interface Props {
+    minWidth?: number;
+    maxWidth?: number | null;
+    id: number;
+    resizeStart?: () => void;
+    resizeEnd?: (width: number) => void;
+    className?: string;
+    disabled?: boolean;
+    defaultWidth?: number;
+    rowSpan?: number;
+    colSpan?: number;
+  }
 
-
-	export interface Props {
-        minWidth: number;
-        maxWidth: number | null;
-        id: number;
-        resizeStart(): void;
-        resizeEnd(width: number): void;
-        className: string;
-        disabled: boolean;
-        defaultWidth?: number;
-        rowSpan?: number;
-        colSpan?: number;
-      }
-    
-    export default function ColumnResizer(props: Props): JSX.Element;
-
+  export default function ColumnResizer(props: Props): JSX.Element;
 }


### PR DESCRIPTION
The current typings cause errors when trying to use the library without providing all props. This PR marks all props, except `id`, as optional.

![image](https://github.com/user-attachments/assets/f32acd9e-d013-4e70-9fc3-dc14e170ce1d)
