### PR TITLE
Fix TypeScript typings resolution when package.json "exports" is enforced

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "private": false,
   "exports": {
     ".": {
+      "types": "./dist/column-resizer.d.ts",
       "import": "./dist/esm/column-resizer.js",
       "require": "./dist/cjs/column-resizer.js"
     }


### PR DESCRIPTION
### Summary
TypeScript fails to resolve the bundled declaration file when consumers use modern module resolution that respects `package.json` `exports` (e.g., `moduleResolution: "bundler"`, `node16`, `nodenext`). Although the `.d.ts` exists and the package sets `types`, TS cannot reach it through the export map and falls back to `any` (TS7016).

### Problem
Consumers see an error similar to:
- `Could not find a declaration file for module 'react-table-column-resizer' ... could not be resolved when respecting package.json "exports" (TS7016)`

The typings exist at `dist/column-resizer.d.ts`, but the export map does not reliably expose them under the main entrypoint.

### Changes
- Update `package.json` `exports` for `"."` to explicitly expose the declaration file via a `types` condition (and keep existing runtime entrypoints intact).
- (Optional, if included) Add `default` entry to improve compatibility across tooling.

### Impact
- No runtime behavior change.
- Restores correct typings for TypeScript projects that enforce `exports`.

### Verification
- TypeScript typecheck succeeds with `moduleResolution: "bundler"` and `moduleResolution: "node16/nodenext"`.
- Existing `import` / `require` entrypoints continue to work.